### PR TITLE
feat: use FactoryBot instead of stubbing .new

### DIFF
--- a/spec/POROs/forecast_repo_spec.rb
+++ b/spec/POROs/forecast_repo_spec.rb
@@ -2,30 +2,15 @@ require 'rails_helper'
 
 RSpec.describe ForecastRepo do
   before :each do
-    allow_any_instance_of(CurrentForecast)
-      .to receive(:initialize)
-      .with({})
-      .and_return(an_instance_of(CurrentForecast))
-
-    allow_any_instance_of(HourlyForecast)
-      .to receive(:initialize)
-      .with({})
-      .and_return(an_instance_of(HourlyForecast))
-
-    allow_any_instance_of(DailyForecast)
-      .to receive(:initialize)
-      .with({})
-      .and_return(an_instance_of(DailyForecast))
-
     @forecast_repo_data = {
-      current_forecast: CurrentForecast.new({}),
+      current_forecast: build(:current_forecast),
       hourly_forecasts: [],
       daily_forecasts: []
     }
 
     8.times do
-      @forecast_repo_data[:hourly_forecasts] << HourlyForecast.new({})
-      @forecast_repo_data[:daily_forecasts] << DailyForecast.new({})
+      @forecast_repo_data[:hourly_forecasts] << build(:hourly_forecast)
+      @forecast_repo_data[:daily_forecasts] << build(:daily_forecast)
     end
   end
 

--- a/spec/factories/current_forecast.rb
+++ b/spec/factories/current_forecast.rb
@@ -1,0 +1,33 @@
+FactoryBot.define do
+  factory :current_forecast do
+    datetime    = Time.now
+    sunrise     = Time.now - 3.hours
+    sunset      = Time.now + 10.hours
+    temperature = Faker::Number.decimal(l_digits: 2, r_digits: 2)
+    feels_like  = Faker::Number.decimal(l_digits: 2, r_digits: 2)
+    humidity    = Faker::Number.within(range: 0..100)
+    uvi         = Faker::Number.decimal(l_digits: 1, r_digits: 2)
+    visibility  = Faker::Number.within(range: 0..10000)
+    conditions  = ['rainy', 'cloudy', 'sunny', 'snow'].sample
+    icon        = '01a'
+
+    hash = {
+      dt: datetime.to_i,
+      sunrise: sunrise.to_i,
+      sunset: sunset.to_i,
+      temp: temperature,
+      feels_like: feels_like,
+      humidity: humidity,
+      uvi: uvi,
+      visibility: visibility,
+      weather: [
+        {
+          description: conditions,
+          icon: icon,
+        }
+      ]
+    }  
+
+    initialize_with { new(hash) }
+  end
+end

--- a/spec/factories/daily_forecast.rb
+++ b/spec/factories/daily_forecast.rb
@@ -1,0 +1,29 @@
+FactoryBot.define do 
+  factory :daily_forecast do
+    date = Time.now.to_i
+    sunrise = (Time.now - 3.hours).to_i
+    sunset = (Time.now + 10.hours).to_i
+    max_temp = Faker::Number.decimal(l_digits: 2, r_digits: 2)
+    min_temp = Faker::Number.decimal(l_digits: 2, r_digits: 2)
+    conditions = ['snowy', 'rainy', 'cloudy', 'sunny'].sample
+    icon = 'o1a'
+
+    hash = {
+      dt: date,
+      sunrise: sunrise,
+      sunset: sunset,
+      temp: {
+        max: max_temp,
+        min: min_temp,
+      },
+      weather: [
+        {
+          description: conditions,
+          icon: icon,
+        }
+      ]
+    }
+
+    initialize_with { new(hash) }
+  end
+end

--- a/spec/factories/hourly_forecast.rb
+++ b/spec/factories/hourly_forecast.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :hourly_forecast do
+    datetime = Time.now.to_i
+    temp = Faker::Number.decimal(l_digits: 2, r_digits: 2)
+    conditions = ['rainy', 'snowy', 'sunny', 'cloudy'].sample
+    icon = 'o1b'
+
+    hash = {
+      dt: datetime,
+      temp: temp,
+      weather: [
+        {
+          description: conditions,
+          icon: icon,
+        }
+      ]
+    }
+
+    initialize_with { new(hash) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
+  config.include FactoryBot::Syntax::Methods
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
Built some Factories to handle initializing POROs, which got rid of the warning messages that were being displayed every time the test suite ran.